### PR TITLE
Add domain models and adapters

### DIFF
--- a/RoEFactura/AntiCorruption/CreditNoteAdapter.cs
+++ b/RoEFactura/AntiCorruption/CreditNoteAdapter.cs
@@ -1,0 +1,116 @@
+using System.Linq;
+using RoEFactura.Domain;
+using UblSharp;
+using UblSharp.CommonAggregateComponents;
+using UblSharp.UnqualifiedDataTypes;
+
+namespace RoEFactura.AntiCorruption;
+
+public static class CreditNoteAdapter
+{
+    public static CreditNoteType ToUbl(CreditNote creditNote)
+    {
+        var ubl = new CreditNoteType
+        {
+            ID = new IdentifierType { Value = creditNote.Id },
+            IssueDate = new DateType { Value = creditNote.IssueDate },
+            DocumentCurrencyCode = new CodeType { Value = creditNote.Currency },
+            AccountingSupplierParty = new SupplierPartyType { Party = ToUblParty(creditNote.Supplier) },
+            AccountingCustomerParty = new CustomerPartyType { Party = ToUblParty(creditNote.Customer) },
+            LegalMonetaryTotal = new MonetaryTotalType
+            {
+                PayableAmount = new AmountType { Value = creditNote.Total, currencyID = creditNote.Currency }
+            }
+        };
+
+        foreach (var line in creditNote.Lines)
+        {
+            var lineType = new CreditNoteLineType
+            {
+                ID = new IdentifierType { Value = line.LineNumber.ToString() },
+                CreditedQuantity = new QuantityType { Value = line.Quantity },
+                LineExtensionAmount = new AmountType { Value = line.LineTotal, currencyID = creditNote.Currency },
+                Item = new ItemType
+                {
+                    Description = [ new TextType { Value = line.Description } ]
+                },
+                Price = new PriceType
+                {
+                    PriceAmount = new AmountType { Value = line.UnitPrice, currencyID = creditNote.Currency }
+                }
+            };
+
+            ubl.CreditNoteLine.Add(lineType);
+        }
+
+        return ubl;
+    }
+
+    public static CreditNote FromUbl(CreditNoteType ubl)
+    {
+        var cn = new CreditNote
+        {
+            Id = ubl.ID?.Value ?? string.Empty,
+            IssueDate = ubl.IssueDate ?? DateTime.MinValue,
+            Currency = ubl.DocumentCurrencyCode?.Value ?? "RON",
+            Supplier = FromUblParty(ubl.AccountingSupplierParty?.Party),
+            Customer = FromUblParty(ubl.AccountingCustomerParty?.Party)
+        };
+
+        if (ubl.CreditNoteLine != null)
+        {
+            foreach (var line in ubl.CreditNoteLine)
+            {
+                cn.Lines.Add(new InvoiceLine
+                {
+                    LineNumber = int.TryParse(line.ID?.Value, out var n) ? n : 0,
+                    Description = line.Item?.Description?.FirstOrDefault()?.Value ?? string.Empty,
+                    Quantity = line.CreditedQuantity?.Value ?? 0m,
+                    UnitPrice = line.Price?.PriceAmount?.Value ?? 0m
+                });
+            }
+        }
+
+        return cn;
+    }
+
+    private static PartyType ToUblParty(Party party)
+    {
+        return new PartyType
+        {
+            PartyName = new PartyNameType { Name = new NameType { Value = party.Name } },
+            PartyTaxScheme = new[]
+            {
+                new PartyTaxSchemeType { CompanyID = new IdentifierType { Value = party.VatId } }
+            },
+            PostalAddress = new AddressType
+            {
+                StreetName = new NameType { Value = party.Address.Street },
+                CityName = new NameType { Value = party.Address.City },
+                PostalZone = new TextType { Value = party.Address.PostalCode },
+                Country = new CountryType
+                {
+                    IdentificationCode = new CodeType { Value = party.Address.CountryCode }
+                }
+            }
+        };
+    }
+
+    private static Party FromUblParty(PartyType? party)
+    {
+        if (party == null) return new Party();
+
+        return new Party
+        {
+            Name = party.PartyName?.Name?.Value ?? string.Empty,
+            VatId = party.PartyTaxScheme?.FirstOrDefault()?.CompanyID?.Value ?? string.Empty,
+            Address = new Address
+            {
+                Street = party.PostalAddress?.StreetName?.Value ?? string.Empty,
+                City = party.PostalAddress?.CityName?.Value ?? string.Empty,
+                PostalCode = party.PostalAddress?.PostalZone?.Value ?? string.Empty,
+                CountryCode = party.PostalAddress?.Country?.IdentificationCode?.Value ?? string.Empty
+            }
+        };
+    }
+}

--- a/RoEFactura/AntiCorruption/InvoiceAdapter.cs
+++ b/RoEFactura/AntiCorruption/InvoiceAdapter.cs
@@ -1,0 +1,116 @@
+using System.Linq;
+using RoEFactura.Domain;
+using UblSharp;
+using UblSharp.CommonAggregateComponents;
+using UblSharp.UnqualifiedDataTypes;
+
+namespace RoEFactura.AntiCorruption;
+
+public static class InvoiceAdapter
+{
+    public static InvoiceType ToUbl(Invoice invoice)
+    {
+        var ubl = new InvoiceType
+        {
+            ID = new IdentifierType { Value = invoice.Id },
+            IssueDate = new DateType { Value = invoice.IssueDate },
+            DocumentCurrencyCode = new CodeType { Value = invoice.Currency },
+            AccountingSupplierParty = new SupplierPartyType { Party = ToUblParty(invoice.Supplier) },
+            AccountingCustomerParty = new CustomerPartyType { Party = ToUblParty(invoice.Customer) },
+            LegalMonetaryTotal = new MonetaryTotalType
+            {
+                PayableAmount = new AmountType { Value = invoice.Total, currencyID = invoice.Currency }
+            }
+        };
+
+        foreach (var line in invoice.Lines)
+        {
+            var lineType = new InvoiceLineType
+            {
+                ID = new IdentifierType { Value = line.LineNumber.ToString() },
+                InvoicedQuantity = new QuantityType { Value = line.Quantity },
+                LineExtensionAmount = new AmountType { Value = line.LineTotal, currencyID = invoice.Currency },
+                Item = new ItemType
+                {
+                    Description = [ new TextType { Value = line.Description } ]
+                },
+                Price = new PriceType
+                {
+                    PriceAmount = new AmountType { Value = line.UnitPrice, currencyID = invoice.Currency }
+                }
+            };
+
+            ubl.InvoiceLine.Add(lineType);
+        }
+
+        return ubl;
+    }
+
+    public static Invoice FromUbl(InvoiceType ubl)
+    {
+        var invoice = new Invoice
+        {
+            Id = ubl.ID?.Value ?? string.Empty,
+            IssueDate = ubl.IssueDate ?? DateTime.MinValue,
+            Currency = ubl.DocumentCurrencyCode?.Value ?? "RON",
+            Supplier = FromUblParty(ubl.AccountingSupplierParty?.Party),
+            Customer = FromUblParty(ubl.AccountingCustomerParty?.Party)
+        };
+
+        if (ubl.InvoiceLine != null)
+        {
+            foreach (var line in ubl.InvoiceLine)
+            {
+                invoice.Lines.Add(new InvoiceLine
+                {
+                    LineNumber = int.TryParse(line.ID?.Value, out var n) ? n : 0,
+                    Description = line.Item?.Description?.FirstOrDefault()?.Value ?? string.Empty,
+                    Quantity = line.InvoicedQuantity?.Value ?? 0m,
+                    UnitPrice = line.Price?.PriceAmount?.Value ?? 0m
+                });
+            }
+        }
+
+        return invoice;
+    }
+
+    private static PartyType ToUblParty(Party party)
+    {
+        return new PartyType
+        {
+            PartyName = new PartyNameType { Name = new NameType { Value = party.Name } },
+            PartyTaxScheme = new[]
+            {
+                new PartyTaxSchemeType { CompanyID = new IdentifierType { Value = party.VatId } }
+            },
+            PostalAddress = new AddressType
+            {
+                StreetName = new NameType { Value = party.Address.Street },
+                CityName = new NameType { Value = party.Address.City },
+                PostalZone = new TextType { Value = party.Address.PostalCode },
+                Country = new CountryType
+                {
+                    IdentificationCode = new CodeType { Value = party.Address.CountryCode }
+                }
+            }
+        };
+    }
+
+    private static Party FromUblParty(PartyType? party)
+    {
+        if (party == null) return new Party();
+
+        return new Party
+        {
+            Name = party.PartyName?.Name?.Value ?? string.Empty,
+            VatId = party.PartyTaxScheme?.FirstOrDefault()?.CompanyID?.Value ?? string.Empty,
+            Address = new Address
+            {
+                Street = party.PostalAddress?.StreetName?.Value ?? string.Empty,
+                City = party.PostalAddress?.CityName?.Value ?? string.Empty,
+                PostalCode = party.PostalAddress?.PostalZone?.Value ?? string.Empty,
+                CountryCode = party.PostalAddress?.Country?.IdentificationCode?.Value ?? string.Empty
+            }
+        };
+    }
+}

--- a/RoEFactura/Domain/Address.cs
+++ b/RoEFactura/Domain/Address.cs
@@ -1,0 +1,9 @@
+namespace RoEFactura.Domain;
+
+public class Address
+{
+    public string Street { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string PostalCode { get; set; } = string.Empty;
+    public string CountryCode { get; set; } = string.Empty;
+}

--- a/RoEFactura/Domain/CreditNote.cs
+++ b/RoEFactura/Domain/CreditNote.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RoEFactura.Domain;
+
+public class CreditNote
+{
+    public string Id { get; set; } = string.Empty;
+    public DateTime IssueDate { get; set; }
+    public string Currency { get; set; } = "RON";
+    public Party Supplier { get; set; } = new();
+    public Party Customer { get; set; } = new();
+    public List<InvoiceLine> Lines { get; set; } = new();
+
+    public decimal Total => Lines.Sum(l => l.LineTotal);
+}

--- a/RoEFactura/Domain/Invoice.cs
+++ b/RoEFactura/Domain/Invoice.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RoEFactura.Domain;
+
+public class Invoice
+{
+    public string Id { get; set; } = string.Empty;
+    public DateTime IssueDate { get; set; }
+    public string Currency { get; set; } = "RON";
+    public Party Supplier { get; set; } = new();
+    public Party Customer { get; set; } = new();
+    public List<InvoiceLine> Lines { get; set; } = new();
+
+    public decimal Total => Lines.Sum(l => l.LineTotal);
+}

--- a/RoEFactura/Domain/InvoiceLine.cs
+++ b/RoEFactura/Domain/InvoiceLine.cs
@@ -1,0 +1,11 @@
+namespace RoEFactura.Domain;
+
+public class InvoiceLine
+{
+    public int LineNumber { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public decimal Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+    public decimal VatRate { get; set; }
+    public decimal LineTotal => Quantity * UnitPrice;
+}

--- a/RoEFactura/Domain/Party.cs
+++ b/RoEFactura/Domain/Party.cs
@@ -1,0 +1,8 @@
+namespace RoEFactura.Domain;
+
+public class Party
+{
+    public string Name { get; set; } = string.Empty;
+    public string VatId { get; set; } = string.Empty;
+    public Address Address { get; set; } = new();
+}

--- a/RoEFactura/RoEFactura.csproj
+++ b/RoEFactura/RoEFactura.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="UblSharp" Version="7.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add Domain models for Invoice, CreditNote, Party and other related classes
- add anti-corruption adapters for Invoice and CreditNote
- reference UblSharp nuget package

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852cb69677c832c9e2c45913ecbcb21