### PR TITLE
Add DI registration extension method

### DIFF
--- a/RoEFactura/ServiceCollectionExtensions.cs
+++ b/RoEFactura/ServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using RoEFactura.Services.Api;
+using RoEFactura.Services.Authentication;
+using RoEFactura.Utilities;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddRoEFactura(this IServiceCollection services)
+    {
+        // Register HTTP clients for API access
+        services.AddHttpClient<AnafEInvoiceClient>();
+        services.AddHttpClient<OAuthHttpClient>();
+
+        // Register other services
+        services.AddTransient<AnafOAuthClient>();
+        services.AddTransient<XmlFileDeserializer>();
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary
- add extension method `AddRoEFactura` that registers HTTP clients and services

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e51e39c8832cb5ed95a07f7325a8